### PR TITLE
修复FTX接口代理连接Bug

### DIFF
--- a/vnpy_ftx/ftx_gateway.py
+++ b/vnpy_ftx/ftx_gateway.py
@@ -330,8 +330,8 @@ class FtxRestApi(RestClient):
         """连接REST服务器"""
         self.key = key
         self.secret = secret.encode()
-        self.proxy_port = proxy_host
-        self.proxy_host = proxy_port
+        self.proxy_host = proxy_host
+        self.proxy_port = proxy_port
 
         self.connect_time = (
             int(datetime.now().strftime("%y%m%d%H%M%S")) * self.order_count


### PR DESCRIPTION

## 改进内容

1.  修复FTX接口使用代理时报错的 BUG

## 相关的Issue号（如有）

无